### PR TITLE
优化FormBuilder ColumnType select2组件

### DIFF
--- a/src/Library/Qscmf/Builder/FormType/Select2/Select2.class.php
+++ b/src/Library/Qscmf/Builder/FormType/Select2/Select2.class.php
@@ -8,6 +8,7 @@ class Select2 implements FormType {
 
     public function build(array $form_type){
         $view = new View();
+        $view->assign('gid', \Illuminate\Support\Str::uuid()->toString());
         $view->assign('form', $form_type);
         if($form_type['item_option']['read_only']){
             $content = $view->fetch(__DIR__ . '/select2_read_only.html');

--- a/src/Library/Qscmf/Builder/FormType/Select2/select2.html
+++ b/src/Library/Qscmf/Builder/FormType/Select2/select2.html
@@ -3,7 +3,7 @@
         <label class="left control-label">{$form.title}：</label>
         <div class="right">
             <div>
-                <select name="{$form.name}" class="form-control select input-sm" {$form.extra_attr}>
+                <select name="{$form.name}" class="form-control select input-sm {$gid}" {$form.extra_attr}>
                     <option value="">----请选择----</option>
                     <foreach name="form.options" item="option" key="option_key">
                         <php>if(is_array($option)):</php>
@@ -35,13 +35,13 @@
     <script type="text/javascript">
         var selection_name = "{$form.name}";
 
-        var is_multiple = $("select[name='"+selection_name+"']").attr('multiple');
+        var is_multiple = $('.{$gid}').attr('multiple');
         if (is_multiple==='multiple'){
-            $("select[name='"+selection_name+"']").attr('name', "{$form.name}"+"[]");
             selection_name = "{$form.name}"+"[]";
-            $("select[name='"+selection_name+"']").parents('.form-group').removeClass("item_{$form.name}").addClass("item_"+selection_name);
+            $('.{$gid}').attr('name',selection_name);
+            $('.{$gid}').parents('.form-group').removeClass("item_{$form.name}").addClass("item_"+selection_name);
         }
-        $("select[name='"+selection_name+"']").select2({
+        $('.{$gid}').select2({
             placeholder: " ----请选择----"
         });
     </script>

--- a/src/Library/Qscmf/Builder/FormType/Select2/select2.html
+++ b/src/Library/Qscmf/Builder/FormType/Select2/select2.html
@@ -36,12 +36,17 @@
         var selection_name = "{$form.name}";
 
         var is_multiple = $('.{$gid}').attr('multiple');
+        var dropdownParent = $('.{$gid}').attr('dropdownParent');
+
         if (is_multiple==='multiple'){
             selection_name = "{$form.name}"+"[]";
             $('.{$gid}').attr('name',selection_name);
             $('.{$gid}').parents('.form-group').removeClass("item_{$form.name}").addClass("item_"+selection_name);
         }
-        $('.{$gid}').select2({
-            placeholder: " ----请选择----"
-        });
+
+        var option = {};
+        option.placeholder =  " ----请选择----";
+        if (dropdownParent) option.dropdownParent = $(dropdownParent);
+
+        $('.{$gid}').select2(option);
     </script>


### PR DESCRIPTION
1.修复FormBuilder使用同字段名的select2、select组件，select组件会渲染为select2的bug;
2.FormBuilder ColumnType select2支持属性dropdownParent，可以将此组件放入指定容器内。