### PR TITLE
iframe 尺寸优化

### DIFF
--- a/asset/libs/ueditor/dialogs/insertframe/insertframe.html
+++ b/asset/libs/ueditor/dialogs/insertframe/insertframe.html
@@ -40,6 +40,9 @@
                 <td colspan="2" class="format"><span><var id="lang_input_height"></var></span><input style="width:200px" type="text" id="height"/> px</td>
             </tr>
             <tr>
+                <td>tips: 宽高只在pc端生效</td>
+            </tr>
+            <tr>
                 <td><label><span><var id="lang_input_isScroll"></var></span><input type="checkbox" id="scroll"/> </label></td>
                 <td><label><span><var id="lang_input_frameborder"></var></span><input type="checkbox" id="frameborder"/> </label></td>
             </tr>
@@ -99,6 +102,7 @@
         if(iframeStr.indexOf('http') === 0){
             newIframe.setAttribute("src", iframeStr);
         }
+        newIframe.setAttribute('class','editor-video-iframe');
         /^[1-9]+[.]?\d*$/g.test( width ) ? newIframe.setAttribute("width",width) : "";
         /^[1-9]+[.]?\d*$/g.test( height ) ? newIframe.setAttribute("height",height) : "";
         scroll.checked ?  newIframe.setAttribute("scrolling","yes") : newIframe.setAttribute("scrolling","no");

--- a/asset/libs/ueditor/themes/default/css/ueditor.css
+++ b/asset/libs/ueditor/themes/default/css/ueditor.css
@@ -398,7 +398,7 @@ div.edui-box {
 .edui-default .edui-menuitem .edui-icon {
     width: 20px !important;
     height: 20px !important;
-    background: url(../images/icons.png) 0 -4000px;
+    background: url(../images/icons.png?v=1) 0 -4000px;
     background: url(../images/icons.gif) 0 -4000px\9;
 }
 
@@ -430,7 +430,7 @@ div.edui-box {
 }
 
 .edui-default .edui-toolbar .edui-combox-body .edui-arrow {
-    background: url(../images/icons.png) -741px 0;
+    background: url(../images/icons.png?v=1) -741px 0;
     _background: url(../images/icons.gif) -741px 0;
     height: 20px;
     width: 9px;
@@ -486,7 +486,7 @@ div.edui-box {
 .edui-default .edui-toolbar .edui-splitbutton .edui-icon {
     height: 20px !important;
     width: 20px !important;
-    background-image: url(../images/icons.png);
+    background-image: url(../images/icons.png?v=1);
     background-image: url(../images/icons.gif) \9;
 }
 
@@ -945,7 +945,7 @@ div.edui-box {
 /*splitbutton*/
 .edui-default .edui-toolbar .edui-splitbutton-body .edui-arrow,
 .edui-default .edui-toolbar .edui-menubutton-body .edui-arrow {
-    background: url(../images/icons.png) -741px 0;
+    background: url(../images/icons.png?v=1) -741px 0;
     _background: url(../images/icons.gif) -741px 0;
     height: 20px;
     width: 9px;
@@ -1374,8 +1374,8 @@ div.edui-box {
 
 /*image-insertframe*/
 .edui-default .edui-for-insertframe .edui-dialog-content {
-    width: 350px;
-    height: 210px;
+    width: 360px;
+    height: 250px;
     overflow: hidden;
 }
 
@@ -1762,7 +1762,7 @@ div.edui-box {
     width: 2px;
     height: 20px;
     margin: 2px 4px 2px 3px;
-    background: url(../images/icons.png) -181px 0;
+    background: url(../images/icons.png?v=1) -181px 0;
     background: url(../images/icons.gif) -181px 0 \9;
 }
 


### PR DESCRIPTION
1.插入iframe视频功能，给iframe添加类名，使得前端可以控制样式, 避免iframe尺寸、比例出现问题
调用富文本时：
- pc端用富文本内尺寸控制iframe宽高
- 移动端用article-content样式控制iframe宽高

2.清除icons图标背景图缓存