### PR TITLE
上传组件限制的文件格式、大小与config文件一致；添加全局函数extractParamsByUrl；使用OSS时自动将heic图片转为jpg。

### DIFF
--- a/src/Common/functions.php
+++ b/src/Common/functions.php
@@ -9,6 +9,59 @@
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
 
+if(!function_exists("extractParamsByUrl")){
+    function extractParamsByUrl(string $url, bool $filter_empty = false):array {
+        if(empty($url)){
+            return [];
+        }
+
+        $param_arr = [];
+
+        $url = urldecode($url);
+        isUrl($url) && $url = str_replace(HTTP_PROTOCOL."://".SITE_URL,'',$url);
+
+        $sub_root = str_replace('-', '\-',trim(__ROOT__, '/'));
+        $pattern[0] = "/^(\/$sub_root\/)/";
+        $pattern[1] = "/^\s+|\s+$/";
+        $pattern[2] = "/^\//";
+
+        $url = preg_replace($pattern, '', $url);
+        $spe_index = strpos($url, '?');
+        if ($spe_index !== false){
+            $url_arr = parse_url($url);
+            $path = $url_arr['path'];
+            $query = $url_arr['query'];
+        }else{
+            $path = $url;
+            $query = '';
+        }
+
+        $ext_index = strpos($path, '.');
+        $ext_index !== false && $path = substr($path, 0, strpos($path, '.'));
+        $path_arr = explode("/", $path);
+        $param_temp_arr = array_slice($path_arr, 3);
+        if ($param_temp_arr){
+            $param_temp_length = count($param_temp_arr);
+            $param_temp_length%2 !== 0 && $param_temp_arr[] = '';
+            collect($param_temp_arr)->each(function($value,$key)use(&$key_arr, &$val_arr){
+                if($key === 0 || $key%2 === 0){
+                    $key_arr[] = $value;
+                }else{
+                    $val_arr[] = $value;
+                }
+            });
+            $param_arr = array_combine($key_arr, $val_arr);
+        }
+
+        if ($query){
+            parse_str($query, $query_arr);
+            $param_arr = array_merge($param_arr,$query_arr);
+        }
+
+        return $filter_empty === true ? array_filter($param_arr) : $param_arr;
+    }
+}
+
 if(!function_exists("isJson")){
     function isJson($string) {
 

--- a/src/Library/Qscmf/Builder/FormType/File/File.class.php
+++ b/src/Library/Qscmf/Builder/FormType/File/File.class.php
@@ -3,14 +3,19 @@ namespace Qscmf\Builder\FormType\File;
 
 use Illuminate\Support\Str;
 use Qscmf\Builder\FormType\FormType;
+use Qscmf\Builder\FormType\TUploadConfig;
 use Think\View;
 
 class File implements FormType {
+    use TUploadConfig;
 
     public function build(array $form_type){
+        $upload_type = $this->genUploadConfigCls($form_type['extra_attr'], 'file');
         $view = new View();
         $view->assign('form', $form_type);
         $view->assign('gid', Str::uuid());
+        $view->assign('file_ext',  $upload_type->getExts());
+        $view->assign('file_max_size',  $upload_type->getMaxSize());
         $content = $view->fetch(__DIR__ . '/file.html');
         return $content;
     }

--- a/src/Library/Qscmf/Builder/FormType/File/file.html
+++ b/src/Library/Qscmf/Builder/FormType/File/file.html
@@ -27,10 +27,8 @@
                     $('#{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#{$gid}').data('url'),
-                        fileTypeExts: fileExts||'*.gif;*.jpg;*.jpeg;*.png;'+
-                            '*.swf;*.flv;*.mp3;*.wav;*.wma;*.wmv;*.mid;*.avi;*.mpg;*.asf;*.rm;*.rmvb;*.mp4;'+
-                            '*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.pdf;*.wps;*.txt;*.zip;*.rar;*.gz;*.bz2;*.7z',
-                        fileSizeLimit: maxSize||(30*1024),
+                        fileTypeExts: fileExts,
+                        fileSizeLimit: maxSize,
                         buttonText:'上传文件',
                         onUploadComplete:function(file, data){
                             var data = $.parseJSON(data);

--- a/src/Library/Qscmf/Builder/FormType/File/file.html
+++ b/src/Library/Qscmf/Builder/FormType/File/file.html
@@ -21,17 +21,19 @@
             </notempty>
             <script type="text/javascript">
                 $(function(){
+                    var fileExts = "{$file_ext}";
+                    var maxSize = "{$file_max_size}";
+
                     $('#{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#{$gid}').data('url'),
-                        fileTypeExts:'*.gif;*.jpg;*.jpeg;*.png;'+
-                                     '*.swf;*.flv;*.mp3;*.wav;*.wma;*.wmv;*.mid;*.avi;*.mpg;*.asf;*.rm;*.rmvb;*.mp4;'+
-                                     '*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.pdf;*.wps;*.txt;*.zip;*.rar;*.gz;*.bz2;*.7z',
-                        fileSizeLimit:<php> echo C('UPLOAD_FILE_SIZE') ? : 30; </php>*1024,
+                        fileTypeExts: fileExts||'*.gif;*.jpg;*.jpeg;*.png;'+
+                            '*.swf;*.flv;*.mp3;*.wav;*.wma;*.wmv;*.mid;*.avi;*.mpg;*.asf;*.rm;*.rmvb;*.mp4;'+
+                            '*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.pdf;*.wps;*.txt;*.zip;*.rar;*.gz;*.bz2;*.7z',
+                        fileSizeLimit: maxSize||(30*1024),
                         buttonText:'上传文件',
                         onUploadComplete:function(file, data){
                             var data = $.parseJSON(data);
-                            console.log(data);
                             if(data.status == 0){
                                 toastr.remove();
                                 $.bs_messagebox('错误', data.info, 'ok');

--- a/src/Library/Qscmf/Builder/FormType/Files/Files.class.php
+++ b/src/Library/Qscmf/Builder/FormType/Files/Files.class.php
@@ -4,13 +4,19 @@ namespace Qscmf\Builder\FormType\Files;
 use Illuminate\Support\Str;
 use Qscmf\Builder\FormType\FormType;
 use Think\View;
+use Qscmf\Builder\FormType\TUploadConfig;
 
 class Files implements FormType {
 
+    use TUploadConfig;
+
     public function build(array $form_type){
+        $upload_type = $this->genUploadConfigCls($form_type['extra_attr'], 'file');
         $view = new View();
         $view->assign('form', $form_type);
         $view->assign('gid', Str::uuid());
+        $view->assign('file_ext',  $upload_type->getExts());
+        $view->assign('file_max_size',  $upload_type->getMaxSize());
         $content = $view->fetch(__DIR__ . '/files.html');
         return $content;
     }

--- a/src/Library/Qscmf/Builder/FormType/Files/files.html
+++ b/src/Library/Qscmf/Builder/FormType/Files/files.html
@@ -24,13 +24,15 @@
             </notempty>
             <script type="text/javascript">
                 $(function(){
+                    var fileExts = "{$file_ext}";
+                    var maxSize = "{$file_max_size}";
                     $('#upload_{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#upload_{$gid}').data('url'),
-                        fileTypeExts:'*.gif;*.jpg;*.jpeg;*.png;'+
+                        fileTypeExts: fileExts || '*.gif;*.jpg;*.jpeg;*.png;'+
                                      '*.swf;*.flv;*.mp3;*.wav;*.wma;*.wmv;*.mid;*.avi;*.mpg;*.asf;*.rm;*.rmvb;*.mp4;'+
                                      '*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.pdf;*.wps;*.txt;*.zip;*.rar;*.gz;*.bz2;*.7z',
-                        fileSizeLimit:<php> echo C('UPLOAD_FILE_SIZE') ? : 2; </php>*1024,
+                        fileSizeLimit:maxSize||(2*1024),
                         buttonText:'添加文件',
                         onUploadComplete:function(file, data){
                             var data = $.parseJSON(data);

--- a/src/Library/Qscmf/Builder/FormType/Files/files.html
+++ b/src/Library/Qscmf/Builder/FormType/Files/files.html
@@ -29,10 +29,8 @@
                     $('#upload_{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#upload_{$gid}').data('url'),
-                        fileTypeExts: fileExts || '*.gif;*.jpg;*.jpeg;*.png;'+
-                                     '*.swf;*.flv;*.mp3;*.wav;*.wma;*.wmv;*.mid;*.avi;*.mpg;*.asf;*.rm;*.rmvb;*.mp4;'+
-                                     '*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.pdf;*.wps;*.txt;*.zip;*.rar;*.gz;*.bz2;*.7z',
-                        fileSizeLimit:maxSize||(2*1024),
+                        fileTypeExts: fileExts,
+                        fileSizeLimit:maxSize,
                         buttonText:'添加文件',
                         onUploadComplete:function(file, data){
                             var data = $.parseJSON(data);

--- a/src/Library/Qscmf/Builder/FormType/Picture/Picture.class.php
+++ b/src/Library/Qscmf/Builder/FormType/Picture/Picture.class.php
@@ -4,13 +4,18 @@ namespace Qscmf\Builder\FormType\Picture;
 use Illuminate\Support\Str;
 use Qscmf\Builder\FormType\FormType;
 use Think\View;
+use Qscmf\Builder\FormType\TUploadConfig;
 
 class Picture implements FormType {
+    use TUploadConfig;
 
     public function build(array $form_type){
+        $upload_type = $this->genUploadConfigCls($form_type['extra_attr'], 'image');
         $view = new View();
         $view->assign('form', $form_type);
         $view->assign('gid', Str::uuid());
+        $view->assign('file_ext',  $upload_type->getExts());
+        $view->assign('file_max_size',  $upload_type->getMaxSize());
         if($form_type['item_option']['read_only']){
             $content = $view->fetch(__DIR__ . '/picture_read_only.html');
         }

--- a/src/Library/Qscmf/Builder/FormType/Picture/picture.html
+++ b/src/Library/Qscmf/Builder/FormType/Picture/picture.html
@@ -23,8 +23,8 @@
                     $('#upload_{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#upload_{$gid}').data('url'),
-                        fileTypeExts:fileExts || '*.gif;*.jpg;*.jpeg;*.png;*.bmp',
-                        fileSizeLimit:maxSize || (2*1024),
+                        fileTypeExts:fileExts,
+                        fileSizeLimit:maxSize,
                         buttonText:'上传图片',
                         onUploadComplete:function(file, data){
                             console.log(data);

--- a/src/Library/Qscmf/Builder/FormType/Picture/picture.html
+++ b/src/Library/Qscmf/Builder/FormType/Picture/picture.html
@@ -17,11 +17,14 @@
             </notempty>
             <script type="text/javascript">
                 $(function(){
+                    var fileExts = "{$file_ext}";
+                    var maxSize = "{$file_max_size}";
+
                     $('#upload_{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#upload_{$gid}').data('url'),
-                        fileTypeExts:'*.gif;*.jpg;*.jpeg;*.png;*.bmp',
-                        fileSizeLimit:<php> echo C('UPLOAD_FILE_SIZE') ? : 2; </php>*1024,
+                        fileTypeExts:fileExts || '*.gif;*.jpg;*.jpeg;*.png;*.bmp',
+                        fileSizeLimit:maxSize || (2*1024),
                         buttonText:'上传图片',
                         onUploadComplete:function(file, data){
                             console.log(data);

--- a/src/Library/Qscmf/Builder/FormType/Pictures/Pictures.class.php
+++ b/src/Library/Qscmf/Builder/FormType/Pictures/Pictures.class.php
@@ -4,13 +4,18 @@ namespace Qscmf\Builder\FormType\Pictures;
 use Illuminate\Support\Str;
 use Qscmf\Builder\FormType\FormType;
 use Think\View;
+use Qscmf\Builder\FormType\TUploadConfig;
 
 class Pictures implements FormType {
+    use TUploadConfig;
 
     public function build(array $form_type){
+        $upload_type = $this->genUploadConfigCls($form_type['extra_attr'], 'image');
         $view = new View();
         $view->assign('form', $form_type);
         $view->assign('gid', Str::uuid());
+        $view->assign('file_ext',  $upload_type->getExts());
+        $view->assign('file_max_size',  $upload_type->getMaxSize());
         if($form_type['item_option']['read_only']){
             $content = $view->fetch(__DIR__ . '/pictures_read_only.html');
         }

--- a/src/Library/Qscmf/Builder/FormType/Pictures/pictures.html
+++ b/src/Library/Qscmf/Builder/FormType/Pictures/pictures.html
@@ -17,11 +17,14 @@
             </notempty>
             <script type="text/javascript">
                 $(function(){
+                    var fileExts = "{$file_ext}";
+                    var maxSize = "{$file_max_size}";
+
                     $('#upload_{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#upload_{$gid}').data('url'),
-                        fileTypeExts:'*.gif;*.jpg;*.jpeg;*.png;*.bmp',
-                        fileSizeLimit:<php> echo C('UPLOAD_FILE_SIZE') ? : 2; </php>*1024,
+                        fileTypeExts:fileExts || '*.gif;*.jpg;*.jpeg;*.png;*.bmp',
+                        fileSizeLimit:maxSize || (2*1024),
                         buttonText:'上传图片',
                         onUploadComplete:function(file, data){
                             var data = $.parseJSON(data);

--- a/src/Library/Qscmf/Builder/FormType/Pictures/pictures.html
+++ b/src/Library/Qscmf/Builder/FormType/Pictures/pictures.html
@@ -23,8 +23,8 @@
                     $('#upload_{$gid}').Huploadify({
                         //uploader:'{:U(C("MODULE_MARK")."/Upload/upload")}',
                         uploader:$('#upload_{$gid}').data('url'),
-                        fileTypeExts:fileExts || '*.gif;*.jpg;*.jpeg;*.png;*.bmp',
-                        fileSizeLimit:maxSize || (2*1024),
+                        fileTypeExts:fileExts,
+                        fileSizeLimit:maxSize,
                         buttonText:'上传图片',
                         onUploadComplete:function(file, data){
                             var data = $.parseJSON(data);

--- a/src/Library/Qscmf/Builder/FormType/TUploadConfig.class.php
+++ b/src/Library/Qscmf/Builder/FormType/TUploadConfig.class.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Qscmf\Builder\FormType;
+
+trait TUploadConfig
+{
+
+    protected function genUploadConfigCls($form_extra, $def_type){
+        $type = $this->getType($form_extra, $def_type);
+        return new UploadConfig($type);
+    }
+
+    protected function getType($form_extra, $def_type){
+        if (!$form_extra){
+            return $def_type;
+        }
+        $regex = '/(data-url)(\s*=\s*[\"|\'])(\S*)([\"|\'])/';
+        $r = preg_match($regex, $form_extra, $matches);
+        if (!$r){
+            return $def_type;
+        }
+        $url = $matches[3];
+        $method = $this->getMethod($url);
+        if(strtolower(substr($method,0,6))=='upload') {
+            $type = strtolower(substr($method, 6));
+        }
+        return $type ?? $def_type;
+    }
+
+    protected function getMethod($url){
+        $url = urldecode($url);
+        isUrl($url) && $url = str_replace(HTTP_PROTOCOL."://".SITE_URL,'',$url);
+
+        $sub_root = str_replace('-', '\-',trim(__ROOT__, '/'));
+        $pattern[0] = "/^(\/$sub_root\/)/";
+        $pattern[1] = "/^\s+|\s+$/";
+        $pattern[2] = "/^\//";
+
+        $url = preg_replace($pattern, '', $url);
+        $spe_index = strpos($url, '?');
+        if ($spe_index !== false){
+            $url_arr = parse_url($url);
+            $path = $url_arr['path'];
+        }else{
+            $path = $url;
+        }
+
+        $ext_index = strpos($path, '.');
+        $ext_index !== false && $path = substr($path, 0, strpos($path, '.'));
+        $path_arr = explode("/", $path);
+        return $path_arr[2];
+    }
+
+}

--- a/src/Library/Qscmf/Builder/FormType/UploadConfig.class.php
+++ b/src/Library/Qscmf/Builder/FormType/UploadConfig.class.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Qscmf\Builder\FormType;
+
+class UploadConfig
+{
+    protected array $config;
+
+    public function __construct($type){
+        $this->config = C('UPLOAD_TYPE_' . strtoupper($type));
+    }
+
+    public function getExts(){
+        $exts = $this->config['exts'];
+        if($exts){
+            $exts = '*.'.str_replace(',',';*.', $exts);
+        }
+
+        return $exts;
+    }
+
+    public function __call($method,$args) {
+        if (function_exists($this->$method)){
+            $this->$method($args);
+        }
+        if(substr($method,0,3)==='get') {
+            $key = lcfirst(substr($method, 3));
+            return $this->config[$key];
+        }
+    }
+
+
+}

--- a/src/Library/Qscmf/Builder/FormType/UploadConfig.class.php
+++ b/src/Library/Qscmf/Builder/FormType/UploadConfig.class.php
@@ -14,9 +14,16 @@ class UploadConfig
         $exts = $this->config['exts'];
         if($exts){
             $exts = '*.'.str_replace(',',';*.', $exts);
+        }else{
+            $exts = '*.*';
         }
 
         return $exts;
+    }
+
+    public function getMaxSize(){
+        $maxSize = $this->config['maxSize'];
+        return is_numeric($maxSize) && $maxSize > 0 ? $maxSize : 1024*1024*1024*1024;
     }
 
     public function __call($method,$args) {

--- a/src/Library/Qscmf/Core/FlashError.class.php
+++ b/src/Library/Qscmf/Core/FlashError.class.php
@@ -11,7 +11,7 @@ class FlashError{
     public static function set($error_msg){
         $errors = Flash::get('qs_flash_error');
         if(is_array($errors)){
-            $errors.push($error_msg);
+            $errors[] = $error_msg;
         }
         else{
             $errors = [$error_msg];

--- a/src/Library/Qscmf/Helper/function.php
+++ b/src/Library/Qscmf/Helper/function.php
@@ -536,6 +536,7 @@ if(!function_exists('showFileUrl')){
 
         //如果图片是网络链接，直接返回网络链接
         if(!empty($file_pic_ent['url']) && $file_pic_ent['security'] != 1){
+            \Think\Hook::listen('heic_to_jpg', $file_pic_ent);
             return $file_pic_ent['url'];
         }
 
@@ -546,6 +547,10 @@ if(!function_exists('showFileUrl')){
                 $config = C('UPLOAD_TYPE_' . strtoupper($file_pic_ent['cate']));
                 $object = trim(str_replace($config['oss_host'], '', $file_pic_ent['url']), '/');
                 $url = $ali_oss->getOssClient($file_pic_ent['cate'])->signUrl($object, 60);
+                $file_tmp = $file_pic_ent;
+                $file_tmp['url'] = $url;
+                \Think\Hook::listen('heic_to_jpg', $file_tmp);
+                $url = $file_tmp['url'];
                 return $url;
             }
 


### PR DESCRIPTION
1. 修复FlashError追加msg失败bug；
2. 上传组件限制的文件格式、大小与config文件一致；
3. 添加全局函数extractParamsByUrl，用于从url中提取参数；
4. showFileUrl添加heic图片转为jpg的钩子，相关上传组件可自定义处理。