### PR TITLE
测试用例使用PUT请求或者请求的CONTENT_TYPE为application/json时，自动模拟提交json数据；修复测试用例提交参数二维数组导致空数组调用类方法bug。

### DIFF
--- a/src/Common/functions.php
+++ b/src/Common/functions.php
@@ -401,7 +401,7 @@ function I($name,$default='',$filter=null,$datas=null) {
     	$method = in_array($_SERVER['REQUEST_METHOD'], ['PUT', 'POST']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
     }
 
-    $wall = app()->make(\Qscmf\Lib\Wall::class);
+    $wall = app()->make(\Testing\TestingWall::class);
 
     switch(strtolower($method)) {
         case 'get'     :   

--- a/src/Common/functions.php
+++ b/src/Common/functions.php
@@ -410,7 +410,7 @@ function I($name,$default='',$filter=null,$datas=null) {
         case 'post'    :
             if(empty($_POST)){
                 $post_tmp = $wall->file_get_contents('php://input');
-                if(strpos($_SERVER['HTTP_CONTENT_TYPE'], 'application/json') !== false){
+                if(is_json_content_type()){
                     $_POST = json_decode($post_tmp, true);
                 }
                 else{
@@ -420,13 +420,11 @@ function I($name,$default='',$filter=null,$datas=null) {
         	$input =& $_POST;
         	break;
         case 'put'     :
-            if(isTesting()){
-                $_PUT = $_POST;
-            }
-            if(strpos($_SERVER['HTTP_CONTENT_TYPE'], 'application/json') !== false){
-                $_PUT = json_decode($wall->file_get_contents('php://input'), true);
+            $put_temp = $wall->file_get_contents('php://input');
+            if(is_json_content_type()){
+                $_PUT = json_decode($put_temp, true);
             }elseif (is_null($_PUT)){
-                parse_str($wall->file_get_contents('php://input'), $_PUT);
+                parse_str($put_temp, $_PUT);
             }
         	$input 	=	$_PUT;        
         	break;
@@ -1767,4 +1765,10 @@ function think_filter(&$value){
 // 不区分大小写的in_array实现
 function in_array_case($value,$array){
     return in_array(strtolower($value),array_map('strtolower',$array));
+}
+
+if (!function_exists('is_json_content_type')) {
+    function is_json_content_type():bool{
+        return isset($_SERVER['HTTP_CONTENT_TYPE']) && str_contains($_SERVER['HTTP_CONTENT_TYPE'], 'application/json');
+    }
 }

--- a/src/Testing/MakesHttpRequests.php
+++ b/src/Testing/MakesHttpRequests.php
@@ -348,12 +348,14 @@ trait MakesHttpRequests
 
     protected function mockPhpInput($value): void
     {
-        $fill_json = is_array($value) ? http_build_query($value) : $value;
-        $stub = $this->createMock(Wall::class);
-        $stub->method('file_get_contents')->willReturnMap([
-            ['php://input', false, null, 0, null, $fill_json]
-        ]);
-        app()->instance(Wall::class, $stub);
+        if(!app()->bound(\Qscmf\Lib\Wall::class)){
+            $fill_json = is_array($value) ? http_build_query($value) : $value;
+            $stub = $this->createMock(Wall::class);
+            $stub->method('file_get_contents')->willReturnMap([
+                ['php://input', false, null, 0, null, $fill_json]
+            ]);
+            app()->instance(Wall::class, $stub);
+        }
     }
 
     /**

--- a/src/Testing/MakesHttpRequests.php
+++ b/src/Testing/MakesHttpRequests.php
@@ -2,7 +2,6 @@
 namespace Testing;
 
 use Illuminate\Support\Str;
-use Qscmf\Lib\Wall;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 
@@ -343,19 +342,17 @@ trait MakesHttpRequests
                 'error' => $file->getError(),
                 'size' => $file->getSize()
             ];
-        }, $request->files->all());
+        }, array_filter($request->files->all(), fn($file) => $file instanceof SymfonyUploadedFile));
     }
 
     protected function mockPhpInput($value): void
     {
-        if(!app()->bound(\Qscmf\Lib\Wall::class)){
-            $fill_json = is_array($value) ? http_build_query($value) : $value;
-            $stub = $this->createMock(Wall::class);
-            $stub->method('file_get_contents')->willReturnMap([
-                ['php://input', false, null, 0, null, $fill_json]
-            ]);
-            app()->instance(Wall::class, $stub);
-        }
+        $fill_json = is_array($value) ? http_build_query($value) : $value;
+        $stub = $this->createMock(TestingWall::class);
+        $stub->method('file_get_contents')->willReturnMap([
+            ['php://input', false, null, 0, null, $fill_json]
+        ]);
+        app()->instance(TestingWall::class, $stub);
     }
 
     /**

--- a/src/Testing/TestingWall.php
+++ b/src/Testing/TestingWall.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Testing;
+
+class TestingWall
+{
+    public function file_get_contents (string $filename, bool $use_include_path = false, ?string $context = null, int $offset = 0, ?int $length = null): string|false{
+        if (is_null($length)){
+            return file_get_contents($filename,$use_include_path,$context,$offset);
+        }else{
+            return file_get_contents($filename,$use_include_path,$context,$offset,$length);
+        }
+    }
+
+}


### PR DESCRIPTION
1. 测试用例使用PUT请求或者请求的CONTENT_TYPE为application/json时，自动模拟提交json数据；
2. 修复测试用例提交参数含有二维数组，被识别为UploadFile类，导致 空数组调用改类方法的bug。