### PR TITLE
修改src/Library/Qscmf/Builder/FormType/Ueditor/ueditor.html文件

### DIFF
--- a/src/Library/Qscmf/Builder/FormType/Ueditor/ueditor.html
+++ b/src/Library/Qscmf/Builder/FormType/Ueditor/ueditor.html
@@ -179,7 +179,7 @@
                             'afterInsertRichText': function (e, html) {
                                 me.execCommand('cleardoc');
                                 filter.call(me, html);
-                                me.document.body.innerHTML = html;
+                                me.document.body.innerHTML = `<div>${html}</div>`;
 
                                 me.fireEvent('catchremoteimage');
 


### PR DESCRIPTION
修改后台富文本解析微信链接导入富文本的时候，如果得到的标签根元素不唯一，导致富文本容器没有出现滚动条。