### PR TITLE
测试添加队列测试

### DIFF
--- a/src/Library/Qscmf/Controller/TestingController.class.php
+++ b/src/Library/Qscmf/Controller/TestingController.class.php
@@ -14,7 +14,8 @@ class TestingController extends Controller{
         if($testingCallback instanceof \Closure){
             $result = call_user_func($testingCallback);
             $re_serialize = \Opis\Closure\serialize($result);
-            qs_exit($re_serialize);
+            $content = ['__QSCMF_TESTING_SERIALIZE_START__', $re_serialize, '__QSCMF_TESTING_SERIALIZE_END__'];
+            qs_exit(implode(",", $content));
         }
         else{
             E('testingCallback is null or not a Closure');


### PR DESCRIPTION
1. 修复测试用例；
2. 测试添加队列测试；
3. 将.phpunit.result.cache、phpunit.xml移除版本控制；
4. 添加 phpunit.xml.example；
5. tp.php 取消定义常量：ROOT_PATH；
6. 完善测试文档。