### PR TITLE
refactor(ueditor): 移除 fetchWxContent 函数的类型声明

### DIFF
--- a/asset/libs/ueditor/php/action_wx_rich_text.php
+++ b/asset/libs/ueditor/php/action_wx_rich_text.php
@@ -6,7 +6,7 @@
  * Time: 下午14:33
  */
 
-function fetchWxContent($url): bool|string
+function fetchWxContent($url)
 {
     $opts = array(
         CURLOPT_TIMEOUT => 60,


### PR DESCRIPTION
移除了 fetchWxContent 函数的返回类型声明，以适应 PHP 低版本的兼容性要求。