### PR TITLE
fix(File): 修复文件预览URL生成问题

### DIFF
--- a/src/Library/Qscmf/Builder/FormType/File/File.class.php
+++ b/src/Library/Qscmf/Builder/FormType/File/File.class.php
@@ -18,7 +18,7 @@ class File extends FileFormType implements FormType {
             $file = [];
             $file['url'] = U('/qscmf/resource/download',['file_id'=>$form_type['value']],'',true);
             if($this->needPreview(showFileUrl($form_type['value']))){
-                $file['preview_url'] = $this->genPreviewUrl(showFileUrl($form_type['value']));
+                $file['preview_url'] = $this->genPreviewUrl(HTTP_PROTOCOL . '://' . SITE_URL. showFileUrl($form_type['value']));
             }
             $view->assign('file', $file);
         }


### PR DESCRIPTION
当生成文件预览URL时，确保使用完整的协议和站点URL前缀，
以解决相对路径导致的预览功能异常问题。